### PR TITLE
Update link to repository containing Elm Editor after rename

### DIFF
--- a/public/tools.js
+++ b/public/tools.js
@@ -773,7 +773,7 @@ window.tools =
         },
         {
             "name": "Elm Editor",
-            "githubName": "elm-fullstack/elm-fullstack",
+            "githubName": "elm-time/elm-time",
             "url": "https://elm-editor.com",
             "packageUrl": null,
             "summary": "A web IDE for developing Elm programs",


### PR DESCRIPTION
This commit adapts the catalog to a rename of the GitHub repository. Elm Editor still lives in the same repository, but the repository was renamed recently.